### PR TITLE
Fix profile dropdown overlapping and update UI

### DIFF
--- a/css/profile-card.css
+++ b/css/profile-card.css
@@ -1,8 +1,11 @@
 .profile-card {
   width: 400px;
-  border: none;
+  border: 1px solid var(--glass-border-base);
   border-radius: 10px;
-  background-color: #fff;
+  background: var(--glass-bg-base);
+  backdrop-filter: blur(var(--glass-blur));
+  -webkit-backdrop-filter: blur(var(--glass-blur));
+  box-shadow: var(--glass-shadow);
 }
 
 .profile-card .stats{

--- a/css/vault.css
+++ b/css/vault.css
@@ -17,6 +17,8 @@
     justify-content: space-between;
     align-items: center;
     padding: 15px 25px;
+    position: relative;
+    z-index: 101;
 }
 
 .input-with-icon {
@@ -63,7 +65,7 @@
 .profile-dropdown {
     position: absolute;
     top: 100%; /* Position below the button */
-    right: 0; /* Align to the right of the button */
+    right: 0; /* Align to a right of the button */
     min-width: 200px;
     z-index: 100;
     opacity: 0;


### PR DESCRIPTION
- Fixed an issue where the search bar would overlap the profile dropdown menu. This was caused by a z-index stacking context issue. The `main` element had a `z-index`, but the `nav` element did not, causing the `main` element to render on top. This was resolved by adding a `z-index` to the `nav.top-nav` to create a new stacking context above the `main` element.
- Updated the profile card UI to match the "glassmorphism" style of the rest of the site, using existing CSS variables.